### PR TITLE
Update sri-toolbox to 0.2.0 to fix hash generation issues.

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,6 @@ var crypto = require('crypto'),
 	OPTION_TYPES = {
 		fileName: ['String'],
 		algorithms: ['Array'],
-		type: ['String'],
 		transform: ['Function'],
 		formatter: ['Function'],
 	},
@@ -28,7 +27,6 @@ function error(msg) {
 
 function hash(file, options) {
 	return sriToolbox.generate({
-		type: options.type,
 		algorithms: options.algorithms
 	}, file.contents.toString());
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-sri",
   "description": "SRI integrety hash generator for gulp. Based on gulp-buster.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": {
     "name": "Matthew Conlen",
     "email": "code@mathisonian.com"
@@ -29,7 +29,7 @@
     "gulp-util": "^3.0.1",
     "lodash.defaults": "^2.4.1",
     "object-assign": "^1.0.0",
-    "sri-toolbox": "^0.1.3",
+    "sri-toolbox": "0.2.0",
     "through": "^2.3.4"
   },
   "engines": {

--- a/test/main.js
+++ b/test/main.js
@@ -57,7 +57,7 @@ describe('Configuration-independent internal methods', function() {
 
 	describe('_assignOptions()', function() {
 		it('should assign options', function() {
-			var options = { type: 'application/javascript', algorithms: ['sha256'] };
+			var options = { algorithms: ['sha256'] };
 			bust._assignOptions(options).should.eql(assign({}, bust._DEFAULT_OPTIONS, options));
 		});
 


### PR DESCRIPTION
We experienced issues generating the proper hashes because of an older version of sri-toolbox. The interface remains largely the same.
